### PR TITLE
Add 60s countdown timer to Hangman with UI timer label

### DIFF
--- a/Visual Studio/Hangman/Hangman.Designer.cs
+++ b/Visual Studio/Hangman/Hangman.Designer.cs
@@ -64,6 +64,7 @@
             lblWord = new Label();
             tblTopRow = new TableLayoutPanel();
             lblHeader = new Label();
+            lblTimer = new Label();
             btnStart = new Button();
             btnGiveUp = new Button();
             tblMain.SuspendLayout();
@@ -550,13 +551,15 @@
             // 
             // tblTopRow
             // 
-            tblTopRow.ColumnCount = 3;
-            tblTopRow.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 60F));
+            tblTopRow.ColumnCount = 4;
+            tblTopRow.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
             tblTopRow.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 20F));
-            tblTopRow.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 20F));
+            tblTopRow.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 15F));
+            tblTopRow.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 15F));
             tblTopRow.Controls.Add(lblHeader, 0, 0);
-            tblTopRow.Controls.Add(btnStart, 1, 0);
-            tblTopRow.Controls.Add(btnGiveUp, 2, 0);
+            tblTopRow.Controls.Add(lblTimer, 1, 0);
+            tblTopRow.Controls.Add(btnStart, 2, 0);
+            tblTopRow.Controls.Add(btnGiveUp, 3, 0);
             tblTopRow.Dock = DockStyle.Fill;
             tblTopRow.Location = new Point(3, 3);
             tblTopRow.Name = "tblTopRow";
@@ -578,15 +581,29 @@
             lblHeader.Text = "HANGMAN";
             lblHeader.TextAlign = ContentAlignment.MiddleCenter;
             // 
+            // lblTimer
+            // 
+            lblTimer.AutoSize = true;
+            lblTimer.BackColor = Color.SkyBlue;
+            lblTimer.Dock = DockStyle.Fill;
+            lblTimer.Font = new Font("Arial Narrow", 13.8F, FontStyle.Bold, GraphicsUnit.Point, 0);
+            lblTimer.ForeColor = SystemColors.ControlLightLight;
+            lblTimer.Location = new Point(400, 0);
+            lblTimer.Name = "lblTimer";
+            lblTimer.Size = new Size(152, 61);
+            lblTimer.TabIndex = 3;
+            lblTimer.Text = "Time Left: 60s";
+            lblTimer.TextAlign = ContentAlignment.MiddleCenter;
+            // 
             // btnStart
             // 
             btnStart.BackColor = Color.SkyBlue;
             btnStart.Dock = DockStyle.Fill;
             btnStart.Font = new Font("Showcard Gothic", 18F, FontStyle.Regular, GraphicsUnit.Point, 0);
             btnStart.ForeColor = SystemColors.ControlLightLight;
-            btnStart.Location = new Point(479, 3);
+            btnStart.Location = new Point(558, 3);
             btnStart.Name = "btnStart";
-            btnStart.Size = new Size(152, 55);
+            btnStart.Size = new Size(113, 55);
             btnStart.TabIndex = 1;
             btnStart.Text = "Start ";
             btnStart.UseVisualStyleBackColor = false;
@@ -597,9 +614,9 @@
             btnGiveUp.Dock = DockStyle.Fill;
             btnGiveUp.Font = new Font("Showcard Gothic", 18F, FontStyle.Regular, GraphicsUnit.Point, 0);
             btnGiveUp.ForeColor = SystemColors.ControlLightLight;
-            btnGiveUp.Location = new Point(637, 3);
+            btnGiveUp.Location = new Point(677, 3);
             btnGiveUp.Name = "btnGiveUp";
-            btnGiveUp.Size = new Size(154, 55);
+            btnGiveUp.Size = new Size(114, 55);
             btnGiveUp.TabIndex = 2;
             btnGiveUp.Text = "GIVE UP";
             btnGiveUp.UseVisualStyleBackColor = false;
@@ -664,5 +681,6 @@
         private Button btnGiveUp;
         private Label lblWord;
         private Label lblWrongGuesses;
+        private Label lblTimer;
     }
 }

--- a/Visual Studio/Hangman/Hangman.cs
+++ b/Visual Studio/Hangman/Hangman.cs
@@ -9,6 +9,9 @@ namespace Hangman
         Char[] cdisplayword;
         Random rnd = new();
         int nwrongguesses = 0;
+        const int GameTimeSeconds = 60;
+        int nsecondsremaining = GameTimeSeconds;
+        readonly System.Windows.Forms.Timer gametimer = new();
 
         public Hangman()
         {
@@ -25,6 +28,9 @@ namespace Hangman
 
             btnStart.Click += BtnStart_Click;
             btnGiveUp.Click += BtnGiveUp_Click;
+            gametimer.Interval = 1000;
+            gametimer.Tick += GameTimer_Tick;
+            UpdateTimerDisplay();
 
             lstbuttons.ForEach(b => b.Enabled = false);
 
@@ -76,6 +82,7 @@ namespace Hangman
         {
             if (nwrongguesses >= 6)
             {
+                gametimer.Stop();
                 lblWord.Text = string.Join(" ", scurrentword.ToCharArray());
                 DisableLetterButtons();
                 btnGiveUp.Enabled = false;
@@ -85,18 +92,43 @@ namespace Hangman
         }
         private void GiveUp()
         {
+            gametimer.Stop();
             lblWord.Text = string.Join(" ", scurrentword.ToCharArray());
             DisableLetterButtons();
+            btnGiveUp.Enabled = false;
+            btnGiveUp.BackColor = Color.White;
             MessageBox.Show("You gave up.", "Game Over");
         }
         private void Winner()
         {
             if (!cdisplayword.Contains('_'))
             {
+                gametimer.Stop();
                 btnGiveUp.Enabled = false;
+                btnGiveUp.BackColor = Color.White;
                 
                 MessageBox.Show("You Win!");
                 DisableLetterButtons();
+            }
+        }
+        private void UpdateTimerDisplay()
+        {
+            lblTimer.Text = $"Time Left: {nsecondsremaining}s";
+        }
+
+        private void GameTimer_Tick(object? sender, EventArgs e)
+        {
+            nsecondsremaining--;
+            UpdateTimerDisplay();
+
+            if (nsecondsremaining <= 0)
+            {
+                gametimer.Stop();
+                lblWord.Text = string.Join(" ", scurrentword.ToCharArray());
+                DisableLetterButtons();
+                btnGiveUp.Enabled = false;
+                btnGiveUp.BackColor = Color.White;
+                MessageBox.Show("Time's up! You lost.", "Game Over");
             }
         }
         private void WhenletterIsClicked(Button btn)
@@ -175,6 +207,9 @@ namespace Hangman
             EnableLetterButtons();
 
             nwrongguesses = 0;
+            nsecondsremaining = GameTimeSeconds;
+            UpdateTimerDisplay();
+            gametimer.Start();
             tblMan.Invalidate();
             DisplayWrongGuesses();
         }


### PR DESCRIPTION
### Motivation
- Provide a per-round countdown so each game has a time limit and rounds end automatically when time expires.
- Surface remaining time in the UI so players can see how much time is left during a round.

### Description
- Added a 60-second round timer via `const int GameTimeSeconds`, an `int nsecondsremaining`, and a WinForms `System.Windows.Forms.Timer gametimer` with `GameTimer_Tick` to decrement time and handle timeout. 
- Start/reset the countdown in `Start()` and stop the timer in `Loser()`, `Winner()`, and `GiveUp()` to keep end-state behavior consistent. 
- Added `UpdateTimerDisplay()` to update a new label `lblTimer` each second and on game start. 
- Updated the UI in the designer by adding `lblTimer` to the top row and changing `tblTopRow` to 4 columns with adjusted control placements and sizes so the timer is visible during play.

### Testing
- Attempted to build with `dotnet build 'Visual Studio/Hangman/Hangman.csproj'`, but the build could not be run in this environment because `dotnet` is not installed (build failed for that reason).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e48701409083339f7b87b57f413298)